### PR TITLE
openapiの変数名変更

### DIFF
--- a/docs/openapi/v1.yml
+++ b/docs/openapi/v1.yml
@@ -138,6 +138,7 @@ components:
         - lgtm
         - pullShark
         - starstruck
+        - none
       description: カードの効果の種類
     LifeEventType:
       title: LifeEventType
@@ -403,11 +404,14 @@ components:
       properties:
         playerId:
           $ref: '#/components/schemas/PlayerId'
+        cardType:
+          $ref: '#/components/schemas/CardType'
         newLife:
           $ref: '#/components/schemas/Life'
           description: 変動後のライフ
       required:
         - playerId
+        - cardType
         - newLife
       description: ライフの変動情報
     WsResponseBodyRailCreated:
@@ -443,10 +447,13 @@ components:
           description: 結合先のレール
         playerId:
           $ref: '#/components/schemas/PlayerId'
+        cardType:
+          $ref: '#/components/schemas/CardType'
       required:
         - childRail
         - parentRail
         - playerId
+        - cardType
       description: レールのマージ情報
     WsResponseBodyBlockCreated:
       type: object
@@ -455,6 +462,8 @@ components:
           $ref: '#/components/schemas/PlayerId'
         targetId:
           $ref: '#/components/schemas/PlayerId'
+        cardType:
+          $ref: '#/components/schemas/CardType'
         delay:
           type: integer
           minimum: 1
@@ -469,6 +478,7 @@ components:
       required:
         - attackerId
         - targetId
+        - cardType
         - delay
         - attack
       description: 新規障害物の作成情報
@@ -479,9 +489,12 @@ components:
           $ref: '#/components/schemas/PlayerId'
         rail:
           $ref: '#/components/schemas/Rail'
+        cardType:
+          $ref: '#/components/schemas/CardType'
       required:
         - targetId
         - rail
+        - cardType
       description: 障害物の解消情報
     WsResponseBodyBlockCrashed:
       type: object
@@ -491,12 +504,15 @@ components:
         rail:
           $ref: '#/components/schemas/Rail'
           description: 衝突したレール
+        cardType:
+          $ref: '#/components/schemas/CardType'
         newLife:
           $ref: '#/components/schemas/Life'
           description: 変動後のライフ
       required:
         - targetId
         - rail
+        - cardType
         - newLife
       description: 障害物と衝突したときの情報
     WsResponseBodyGameOverred:

--- a/docs/openapi/v1.yml
+++ b/docs/openapi/v1.yml
@@ -490,25 +490,28 @@ components:
     WsResponseBodyBlockCanceled:
       type: object
       properties:
+        targetId:
+          $ref: '#/components/schemas/PlayerId'
         rail:
           $ref: '#/components/schemas/Rail'
       required:
+        - targetId
         - rail
       description: 障害物の解消情報
     WsResponseBodyBlockCrashed:
       type: object
       properties:
+        targetId:
+          $ref: '#/components/schemas/PlayerId'
         rail:
           $ref: '#/components/schemas/Rail'
           description: 衝突したレール
-        playerId:
-          $ref: '#/components/schemas/PlayerId'
         newLife:
           $ref: '#/components/schemas/Life'
           description: 変動後のライフ
       required:
+        - targetId
         - rail
-        - playerId
         - newLife
       description: 障害物と衝突したときの情報
     WsResponseBodyGameOverred:

--- a/docs/openapi/v1.yml
+++ b/docs/openapi/v1.yml
@@ -328,10 +328,13 @@ components:
       properties:
         type:
           $ref: '#/components/schemas/BlockEventType'
+        cardType:
+          $ref: '#/components/schemas/CardType'
         rail:
           $ref: '#/components/schemas/Rail'
       required:
         - type
+        - cardType
         - rail
       description: ブロックに関するイベントの情報
     WsResponse:

--- a/docs/openapi/v1.yml
+++ b/docs/openapi/v1.yml
@@ -345,7 +345,6 @@ components:
             - $ref: '#/components/schemas/WsResponseBodyConnected'
             - $ref: '#/components/schemas/WsResponseBodyGameStarted'
             - $ref: '#/components/schemas/WsResponseBodyLifeChanged'
-            - $ref: '#/components/schemas/WsResponseBodyCardReset'
             - $ref: '#/components/schemas/WsResponseBodyRailCreated'
             - $ref: '#/components/schemas/WsResponseBodyRailMerged'
             - $ref: '#/components/schemas/WsResponseBodyBlockCreated'
@@ -369,7 +368,6 @@ components:
         - connected
         - gameStarted
         - lifeChanged
-        - cardReset
         - railCreated
         - railMerged
         - blockCreated
@@ -409,22 +407,6 @@ components:
         - playerId
         - newLife
       description: ライフの変動情報
-    WsResponseBodyCardReset:
-      type: array
-      items:
-        type: object
-        properties:
-          playerId:
-            $ref: '#/components/schemas/PlayerId'
-          cards:
-            type: array
-            items:
-              $ref: '#/components/schemas/Card'
-            description: リセットされたカードのリスト
-        required:
-          - playerId
-          - cards
-      description: 各プレイヤーのカードのリセット情報
     WsResponseBodyRailCreated:
       type: object
       properties:

--- a/docs/openapi/v1.yml
+++ b/docs/openapi/v1.yml
@@ -200,15 +200,11 @@ components:
             $ref: '#/components/schemas/Rail'
           description: プレイヤーのレールのリスト
         life:
-          type: number
-          maximum: 100
-          minimum: 0
-          description: プレイヤーのライフ
+          $ref: '#/components/schemas/Life'
       required:
         - id
         - mainRail
         - rails
-        # - blocks
         - life
       description: プレイヤー情報
     Rail:
@@ -226,6 +222,12 @@ components:
         - id
         - index
       description: レール情報
+    Life:
+      title: Life
+      type: number
+      maximum: 100
+      minimum: 0
+      description: ライフ
     CreateRoomRequest:
       title: CreateRoomRequest
       type: object
@@ -400,14 +402,12 @@ components:
       properties:
         playerId:
           $ref: '#/components/schemas/PlayerId'
-        new:
-          type: number
-          maximum: 100
-          minimum: 0
+        newLife:
+          $ref: '#/components/schemas/Life'
           description: 変動後のライフ
       required:
         - playerId
-        - new
+        - newLife
       description: ライフの変動情報
     WsResponseBodyCardReset:
       type: array
@@ -503,15 +503,13 @@ components:
           description: 衝突したレール
         playerId:
           $ref: '#/components/schemas/PlayerId'
-        new:
-          type: number
-          maximum: 100
-          minimum: 0
+        newLife:
+          $ref: '#/components/schemas/Life'
           description: 変動後のライフ
       required:
         - rail
         - playerId
-        - new
+        - newLife
       description: 障害物と衝突したときの情報
     WsResponseBodyGameOverred:
       type: object

--- a/integration/ws/ws_test.go
+++ b/integration/ws/ws_test.go
@@ -171,7 +171,7 @@ func TestWs(t *testing.T) {
 			require.Equal(t, oapi.WsResponseTypeLifeChanged, res.Type)
 			require.Equal(t, oapi.WsResponseBodyLifeChanged{
 				PlayerId: pids[0],
-				New:      99,
+				NewLife:  99,
 			}, resbody)
 		})
 	})

--- a/integration/ws/ws_test.go
+++ b/integration/ws/ws_test.go
@@ -146,6 +146,7 @@ func TestWs(t *testing.T) {
 			require.Equal(t, oapi.WsResponseBodyBlockCreated{
 				AttackerId: pids[1],
 				TargetId:   pids[0],
+				CardType:   oapi.CardTypePairExtraordinaire,
 				Delay:      2,
 				Attack:     30,
 			}, resbody)
@@ -170,6 +171,7 @@ func TestWs(t *testing.T) {
 			require.NoError(t, err)
 			require.Equal(t, oapi.WsResponseTypeLifeChanged, res.Type)
 			require.Equal(t, oapi.WsResponseBodyLifeChanged{
+				CardType: oapi.CardTypeNone,
 				PlayerId: pids[0],
 				NewLife:  99,
 			}, resbody)

--- a/internal/oapi/constructor.go
+++ b/internal/oapi/constructor.go
@@ -41,9 +41,10 @@ func NewWsResponseGameStarted(eventTime time.Time, players []Player) (*WsRespons
 	return res, nil
 }
 
-func NewWsResponseLifeChanged(eventTime time.Time, playerID uuid.UUID, newLife float32) (*WsResponse, error) {
+func NewWsResponseLifeChanged(eventTime time.Time, playerID uuid.UUID, cardType CardType, newLife float32) (*WsResponse, error) {
 	b := WsResponseBodyLifeChanged{
 		PlayerId: playerID,
+		CardType: cardType,
 		NewLife:  newLife,
 	}
 
@@ -74,11 +75,12 @@ func NewWsResponseRailCreated(eventTime time.Time, newRail, parentRail Rail, att
 	return res, nil
 }
 
-func NewWsResponseRailMerged(eventTime time.Time, childRail, parentRail Rail, playerID uuid.UUID) (*WsResponse, error) {
+func NewWsResponseRailMerged(eventTime time.Time, childRail, parentRail Rail, playerID uuid.UUID, cardType CardType) (*WsResponse, error) {
 	b := WsResponseBodyRailMerged{
 		ChildRail:  childRail,
 		ParentRail: parentRail,
 		PlayerId:   playerID,
+		CardType:   cardType,
 	}
 
 	res := WsResponseFromType(WsResponseTypeRailMerged, eventTime)
@@ -90,10 +92,11 @@ func NewWsResponseRailMerged(eventTime time.Time, childRail, parentRail Rail, pl
 	return res, nil
 }
 
-func NewWsResponseBlockCreated(eventTime time.Time, attackerID uuid.UUID, targetID uuid.UUID, delay int, attack float32) (*WsResponse, error) {
+func NewWsResponseBlockCreated(eventTime time.Time, attackerID uuid.UUID, targetID uuid.UUID, cardType CardType, delay int, attack float32) (*WsResponse, error) {
 	b := WsResponseBodyBlockCreated{
 		AttackerId: attackerID,
 		TargetId:   targetID,
+		CardType:   cardType,
 		Delay:      delay,
 		Attack:     attack,
 	}
@@ -107,10 +110,11 @@ func NewWsResponseBlockCreated(eventTime time.Time, attackerID uuid.UUID, target
 	return res, nil
 }
 
-func NewWsResponseBlockCanceled(eventTime time.Time, targetID uuid.UUID, rail Rail) (*WsResponse, error) {
+func NewWsResponseBlockCanceled(eventTime time.Time, targetID uuid.UUID, rail Rail, cardType CardType) (*WsResponse, error) {
 	b := WsResponseBodyBlockCanceled{
 		TargetId: targetID,
 		Rail:     rail,
+		CardType: cardType,
 	}
 
 	res := WsResponseFromType(WsResponseTypeBlockCanceled, eventTime)
@@ -122,11 +126,12 @@ func NewWsResponseBlockCanceled(eventTime time.Time, targetID uuid.UUID, rail Ra
 	return res, nil
 }
 
-func NewWsResponseBlockCrashed(eventTime time.Time, newLife float32, targetID uuid.UUID, rail Rail) (*WsResponse, error) {
+func NewWsResponseBlockCrashed(eventTime time.Time, newLife float32, targetID uuid.UUID, rail Rail, cardType CardType) (*WsResponse, error) {
 	b := WsResponseBodyBlockCrashed{
 		NewLife:  newLife,
 		TargetId: targetID,
 		Rail:     rail,
+		CardType: cardType,
 	}
 
 	res := WsResponseFromType(WsResponseTypeBlockCrashed, eventTime)

--- a/internal/oapi/constructor.go
+++ b/internal/oapi/constructor.go
@@ -44,7 +44,7 @@ func NewWsResponseGameStarted(eventTime time.Time, players []Player) (*WsRespons
 func NewWsResponseLifeChanged(eventTime time.Time, playerID uuid.UUID, newLife float32) (*WsResponse, error) {
 	b := WsResponseBodyLifeChanged{
 		PlayerId: playerID,
-		New:      newLife,
+		NewLife:  newLife,
 	}
 
 	res := WsResponseFromType(WsResponseTypeLifeChanged, eventTime)
@@ -135,9 +135,9 @@ func NewWsResponseBlockCanceled(eventTime time.Time, rail Rail) (*WsResponse, er
 
 func NewWsResponseBlockCrashed(eventTime time.Time, newLife float32, playerID uuid.UUID, rail Rail) (*WsResponse, error) {
 	b := WsResponseBodyBlockCrashed{
-		New:      newLife,
+		NewLife:  newLife,
 		PlayerId: playerID,
-		Rail:   rail,
+		Rail:     rail,
 	}
 
 	res := WsResponseFromType(WsResponseTypeBlockCrashed, eventTime)
@@ -163,9 +163,9 @@ func NewWsResponseGameOverred(eventTime time.Time, playerID uuid.UUID) (*WsRespo
 	return res, nil
 }
 
-func NewRail(id uuid.UUID, index int) Rail{
+func NewRail(id uuid.UUID, index int) Rail {
 	return Rail{
-		Id: id,
+		Id:    id,
 		Index: index,
 	}
 }

--- a/internal/oapi/constructor.go
+++ b/internal/oapi/constructor.go
@@ -119,8 +119,9 @@ func NewWsResponseBlockCreated(eventTime time.Time, attackerID uuid.UUID, target
 	return res, nil
 }
 
-func NewWsResponseBlockCanceled(eventTime time.Time, rail Rail) (*WsResponse, error) {
+func NewWsResponseBlockCanceled(eventTime time.Time, targetID uuid.UUID, rail Rail) (*WsResponse, error) {
 	b := WsResponseBodyBlockCanceled{
+		TargetId: targetID,
 		Rail: rail,
 	}
 
@@ -133,10 +134,10 @@ func NewWsResponseBlockCanceled(eventTime time.Time, rail Rail) (*WsResponse, er
 	return res, nil
 }
 
-func NewWsResponseBlockCrashed(eventTime time.Time, newLife float32, playerID uuid.UUID, rail Rail) (*WsResponse, error) {
+func NewWsResponseBlockCrashed(eventTime time.Time, newLife float32, targetID uuid.UUID, rail Rail) (*WsResponse, error) {
 	b := WsResponseBodyBlockCrashed{
 		NewLife:  newLife,
-		PlayerId: playerID,
+		TargetId: targetID,
 		Rail:     rail,
 	}
 

--- a/internal/oapi/constructor.go
+++ b/internal/oapi/constructor.go
@@ -56,18 +56,6 @@ func NewWsResponseLifeChanged(eventTime time.Time, playerID uuid.UUID, newLife f
 	return res, nil
 }
 
-func NewWsResponseCardReset(eventTime time.Time) (*WsResponse, error) {
-	b := WsResponseBodyCardReset{}
-
-	res := WsResponseFromType(WsResponseTypeCardReset, eventTime)
-
-	if err := res.Body.FromWsResponseBodyCardReset(b); err != nil {
-		return nil, err
-	}
-
-	return res, nil
-}
-
 func NewWsResponseRailCreated(eventTime time.Time, newRail, parentRail Rail, attackerID, targetID uuid.UUID, cardType CardType) (*WsResponse, error) {
 	b := WsResponseBodyRailCreated{
 		NewRail:    newRail,
@@ -122,7 +110,7 @@ func NewWsResponseBlockCreated(eventTime time.Time, attackerID uuid.UUID, target
 func NewWsResponseBlockCanceled(eventTime time.Time, targetID uuid.UUID, rail Rail) (*WsResponse, error) {
 	b := WsResponseBodyBlockCanceled{
 		TargetId: targetID,
-		Rail: rail,
+		Rail:     rail,
 	}
 
 	res := WsResponseFromType(WsResponseTypeBlockCanceled, eventTime)

--- a/internal/oapi/converter.go
+++ b/internal/oapi/converter.go
@@ -59,3 +59,22 @@ func RoomFromDomain(dr *domain.Room) Room {
 		StartedAt: dr.StartedAt,
 	}
 }
+
+func (t CardType) ToDomain() domain.CardType {
+	m := map[CardType]domain.CardType{
+		CardTypeYolo:               domain.CardTypeYolo,
+		CardTypeGalaxyBrain:        domain.CardTypeGalaxyBrain,
+		CardTypeOpenSourcerer:      domain.CardTypeOpenSourcerer,
+		CardTypeRefactoring:        domain.CardTypeRefactoring,
+		CardTypePairExtraordinaire: domain.CardTypePairExtraordinaire,
+		CardTypeLgtm:               domain.CardTypeLgtm,
+		CardTypePullShark:          domain.CardTypePullShark,
+		CardTypeStarstruck:         domain.CardTypeStarstruck,
+	}
+
+	if t, ok := m[t]; ok {
+		return t
+	}
+
+	return domain.CardTypeNone
+}

--- a/internal/oapi/oapi_models.go
+++ b/internal/oapi/oapi_models.go
@@ -166,6 +166,9 @@ type WsRequest_Body struct {
 
 // WsRequestBodyBlockEvent ブロックに関するイベントの情報
 type WsRequestBodyBlockEvent struct {
+	// CardType カードの効果の種類
+	CardType CardType `json:"cardType"`
+
 	// Rail レール情報
 	Rail Rail `json:"rail"`
 

--- a/internal/oapi/oapi_models.go
+++ b/internal/oapi/oapi_models.go
@@ -222,6 +222,9 @@ type WsResponse_Body struct {
 type WsResponseBodyBlockCanceled struct {
 	// Rail レール情報
 	Rail Rail `json:"rail"`
+
+	// TargetId プレイヤーUUID
+	TargetId PlayerId `json:"targetId"`
 }
 
 // WsResponseBodyBlockCrashed 障害物と衝突したときの情報
@@ -229,11 +232,11 @@ type WsResponseBodyBlockCrashed struct {
 	// NewLife ライフ
 	NewLife Life `json:"newLife"`
 
-	// PlayerId プレイヤーUUID
-	PlayerId PlayerId `json:"playerId"`
-
 	// Rail レール情報
 	Rail Rail `json:"rail"`
+
+	// TargetId プレイヤーUUID
+	TargetId PlayerId `json:"targetId"`
 }
 
 // WsResponseBodyBlockCreated 新規障害物の作成情報

--- a/internal/oapi/oapi_models.go
+++ b/internal/oapi/oapi_models.go
@@ -48,7 +48,6 @@ const (
 	WsResponseTypeBlockCanceled WsResponseType = "blockCanceled"
 	WsResponseTypeBlockCrashed  WsResponseType = "blockCrashed"
 	WsResponseTypeBlockCreated  WsResponseType = "blockCreated"
-	WsResponseTypeCardReset     WsResponseType = "cardReset"
 	WsResponseTypeConnected     WsResponseType = "connected"
 	WsResponseTypeGameOverred   WsResponseType = "gameOverred"
 	WsResponseTypeGameStarted   WsResponseType = "gameStarted"
@@ -252,15 +251,6 @@ type WsResponseBodyBlockCreated struct {
 
 	// TargetId プレイヤーUUID
 	TargetId PlayerId `json:"targetId"`
-}
-
-// WsResponseBodyCardReset 各プレイヤーのカードのリセット情報
-type WsResponseBodyCardReset = []struct {
-	// Cards リセットされたカードのリスト
-	Cards []Card `json:"cards"`
-
-	// PlayerId プレイヤーUUID
-	PlayerId PlayerId `json:"playerId"`
 }
 
 // WsResponseBodyConnected 接続したプレイヤーのID
@@ -517,32 +507,6 @@ func (t *WsResponse_Body) FromWsResponseBodyLifeChanged(v WsResponseBodyLifeChan
 
 // MergeWsResponseBodyLifeChanged performs a merge with any union data inside the WsResponse_Body, using the provided WsResponseBodyLifeChanged
 func (t *WsResponse_Body) MergeWsResponseBodyLifeChanged(v WsResponseBodyLifeChanged) error {
-	b, err := json.Marshal(v)
-	if err != nil {
-		return err
-	}
-
-	merged, err := runtime.JsonMerge(b, t.union)
-	t.union = merged
-	return err
-}
-
-// AsWsResponseBodyCardReset returns the union data inside the WsResponse_Body as a WsResponseBodyCardReset
-func (t WsResponse_Body) AsWsResponseBodyCardReset() (WsResponseBodyCardReset, error) {
-	var body WsResponseBodyCardReset
-	err := json.Unmarshal(t.union, &body)
-	return body, err
-}
-
-// FromWsResponseBodyCardReset overwrites any union data inside the WsResponse_Body as the provided WsResponseBodyCardReset
-func (t *WsResponse_Body) FromWsResponseBodyCardReset(v WsResponseBodyCardReset) error {
-	b, err := json.Marshal(v)
-	t.union = b
-	return err
-}
-
-// MergeWsResponseBodyCardReset performs a merge with any union data inside the WsResponse_Body, using the provided WsResponseBodyCardReset
-func (t *WsResponse_Body) MergeWsResponseBodyCardReset(v WsResponseBodyCardReset) error {
 	b, err := json.Marshal(v)
 	if err != nil {
 		return err

--- a/internal/oapi/oapi_models.go
+++ b/internal/oapi/oapi_models.go
@@ -21,6 +21,7 @@ const (
 const (
 	CardTypeGalaxyBrain        CardType = "galaxyBrain"
 	CardTypeLgtm               CardType = "lgtm"
+	CardTypeNone               CardType = "none"
 	CardTypeOpenSourcerer      CardType = "openSourcerer"
 	CardTypePairExtraordinaire CardType = "pairExtraordinaire"
 	CardTypePullShark          CardType = "pullShark"
@@ -222,6 +223,9 @@ type WsResponse_Body struct {
 
 // WsResponseBodyBlockCanceled 障害物の解消情報
 type WsResponseBodyBlockCanceled struct {
+	// CardType カードの効果の種類
+	CardType CardType `json:"cardType"`
+
 	// Rail レール情報
 	Rail Rail `json:"rail"`
 
@@ -231,6 +235,9 @@ type WsResponseBodyBlockCanceled struct {
 
 // WsResponseBodyBlockCrashed 障害物と衝突したときの情報
 type WsResponseBodyBlockCrashed struct {
+	// CardType カードの効果の種類
+	CardType CardType `json:"cardType"`
+
 	// NewLife ライフ
 	NewLife Life `json:"newLife"`
 
@@ -248,6 +255,9 @@ type WsResponseBodyBlockCreated struct {
 
 	// AttackerId プレイヤーUUID
 	AttackerId PlayerId `json:"attackerId"`
+
+	// CardType カードの効果の種類
+	CardType CardType `json:"cardType"`
 
 	// Delay 障害物を解消するために必要な秒数
 	Delay int `json:"delay"`
@@ -276,6 +286,9 @@ type WsResponseBodyGameStarted struct {
 
 // WsResponseBodyLifeChanged ライフの変動情報
 type WsResponseBodyLifeChanged struct {
+	// CardType カードの効果の種類
+	CardType CardType `json:"cardType"`
+
 	// NewLife ライフ
 	NewLife Life `json:"newLife"`
 
@@ -303,6 +316,9 @@ type WsResponseBodyRailCreated struct {
 
 // WsResponseBodyRailMerged レールのマージ情報
 type WsResponseBodyRailMerged struct {
+	// CardType カードの効果の種類
+	CardType CardType `json:"cardType"`
+
 	// ChildRail レール情報
 	ChildRail Rail `json:"childRail"`
 

--- a/internal/oapi/oapi_models.go
+++ b/internal/oapi/oapi_models.go
@@ -91,6 +91,9 @@ type JoinRoomRequest struct {
 	RoomId RoomId `json:"roomId"`
 }
 
+// Life ライフ
+type Life = float32
+
 // LifeEventType ライフに関するイベントの種類
 type LifeEventType string
 
@@ -99,8 +102,8 @@ type Player struct {
 	// Id プレイヤーUUID
 	Id PlayerId `json:"id"`
 
-	// Life プレイヤーのライフ
-	Life float32 `json:"life"`
+	// Life ライフ
+	Life Life `json:"life"`
 
 	// MainRail レール情報
 	MainRail Rail `json:"mainRail"`
@@ -223,8 +226,8 @@ type WsResponseBodyBlockCanceled struct {
 
 // WsResponseBodyBlockCrashed 障害物と衝突したときの情報
 type WsResponseBodyBlockCrashed struct {
-	// New 変動後のライフ
-	New float32 `json:"new"`
+	// NewLife ライフ
+	NewLife Life `json:"newLife"`
 
 	// PlayerId プレイヤーUUID
 	PlayerId PlayerId `json:"playerId"`
@@ -277,8 +280,8 @@ type WsResponseBodyGameStarted struct {
 
 // WsResponseBodyLifeChanged ライフの変動情報
 type WsResponseBodyLifeChanged struct {
-	// New 変動後のライフ
-	New float32 `json:"new"`
+	// NewLife ライフ
+	NewLife Life `json:"newLife"`
 
 	// PlayerId プレイヤーUUID
 	PlayerId PlayerId `json:"playerId"`

--- a/internal/usecases/services/ws/wshandler/block.go
+++ b/internal/usecases/services/ws/wshandler/block.go
@@ -36,7 +36,7 @@ func (h *wsHandler) handleBlockEvent(reqbody oapi.WsRequest_Body) error {
 			b.Rail.Id,
 		))
 
-		res, err = oapi.NewWsResponseBlockCanceled(now, h.playerID, b.Rail)
+		res, err = oapi.NewWsResponseBlockCanceled(now, h.playerID, b.Rail, b.CardType)
 		if err != nil {
 			return err
 		}
@@ -66,7 +66,13 @@ func (h *wsHandler) handleBlockEvent(reqbody oapi.WsRequest_Body) error {
 			attack,
 		))
 
-		res, err = oapi.NewWsResponseBlockCrashed(now, domain.CalculateLife(target.LifeEvents), target.ID, b.Rail)
+		res, err = oapi.NewWsResponseBlockCrashed(
+			now,
+			domain.CalculateLife(target.LifeEvents),
+			target.ID,
+			b.Rail,
+			b.CardType,
+		)
 		if err != nil {
 			return err
 		}

--- a/internal/usecases/services/ws/wshandler/block.go
+++ b/internal/usecases/services/ws/wshandler/block.go
@@ -29,7 +29,7 @@ func (h *wsHandler) handleBlockEvent(reqbody oapi.WsRequest_Body) error {
 	case oapi.BlockEventTypeCanceled:
 		target.BlockEvents = append(target.BlockEvents, domain.NewBlockEvent(
 			uuid.New(),
-			domain.CardTypeNone,
+			b.CardType.ToDomain(),
 			jst.Now(),
 			domain.BlockEventTypeCanceled,
 			target.ID,
@@ -44,7 +44,7 @@ func (h *wsHandler) handleBlockEvent(reqbody oapi.WsRequest_Body) error {
 	case oapi.BlockEventTypeCrashed:
 		target.BlockEvents = append(target.BlockEvents, domain.NewBlockEvent(
 			uuid.New(),
-			domain.CardTypeNone,
+			b.CardType.ToDomain(),
 			jst.Now(),
 			domain.BlockEventTypeCrashed,
 			target.ID,
@@ -60,7 +60,7 @@ func (h *wsHandler) handleBlockEvent(reqbody oapi.WsRequest_Body) error {
 
 		target.LifeEvents = append(target.LifeEvents, domain.NewLifeEvent(
 			uuid.New(),
-			domain.CardTypeNone,
+			b.CardType.ToDomain(),
 			jst.Now(),
 			domain.LifeEventTypeDamaged,
 			attack,

--- a/internal/usecases/services/ws/wshandler/block.go
+++ b/internal/usecases/services/ws/wshandler/block.go
@@ -36,7 +36,7 @@ func (h *wsHandler) handleBlockEvent(reqbody oapi.WsRequest_Body) error {
 			b.Rail.Id,
 		))
 
-		res, err = oapi.NewWsResponseBlockCanceled(now, b.Rail)
+		res, err = oapi.NewWsResponseBlockCanceled(now, h.playerID, b.Rail)
 		if err != nil {
 			return err
 		}

--- a/internal/usecases/services/ws/wshandler/card.go
+++ b/internal/usecases/services/ws/wshandler/card.go
@@ -95,6 +95,7 @@ func (h *wsHandler) handleYolo(reqbody oapi.WsRequestBodyCardEvent, now time.Tim
 		oapi.NewRail(targetRail.ID, targetRailIndex),
 		oapi.NewRail(targetPlayer.Main.ID, consts.RailLimit/2),
 		h.playerID,
+		oapi.CardTypeYolo,
 	)
 	if err != nil {
 		return nil, err
@@ -129,7 +130,12 @@ func (h *wsHandler) handleOpenSourcerer(reqbody oapi.WsRequestBodyCardEvent, now
 		consts.MaxLife-nowLife,
 	))
 
-	res, err := oapi.NewWsResponseLifeChanged(now, h.playerID, domain.CalculateLife(targetPlayer.LifeEvents))
+	res, err := oapi.NewWsResponseLifeChanged(
+		now,
+		h.playerID,
+		oapi.CardTypeOpenSourcerer,
+		domain.CalculateLife(targetPlayer.LifeEvents),
+	)
 	if err != nil {
 		return nil, err
 	}
@@ -169,7 +175,14 @@ func (h *wsHandler) handleRefactoring(reqbody oapi.WsRequestBodyCardEvent, now t
 		targetRail.ID,
 	))
 
-	res, err := oapi.NewWsResponseBlockCreated(now, h.playerID, reqbody.TargetId, delay, attack)
+	res, err := oapi.NewWsResponseBlockCreated(
+		now,
+		h.playerID,
+		reqbody.TargetId,
+		oapi.CardTypeRefactoring,
+		delay,
+		attack,
+	)
 	if err != nil {
 		return nil, err
 	}
@@ -205,7 +218,14 @@ func (h *wsHandler) handlePairExtraordinaire(reqbody oapi.WsRequestBodyCardEvent
 		targetRail.ID,
 	))
 
-	res, err := oapi.NewWsResponseBlockCreated(now, h.playerID, reqbody.TargetId, delay, attack)
+	res, err := oapi.NewWsResponseBlockCreated(
+		now,
+		h.playerID,
+		reqbody.TargetId,
+		oapi.CardTypePairExtraordinaire,
+		delay,
+		attack,
+	)
 	if err != nil {
 		return nil, err
 	}
@@ -241,7 +261,14 @@ func (h *wsHandler) handleLgtm(reqbody oapi.WsRequestBodyCardEvent, now time.Tim
 		targetRail.ID,
 	))
 
-	res, err := oapi.NewWsResponseBlockCreated(now, h.playerID, reqbody.TargetId, delay, attack)
+	res, err := oapi.NewWsResponseBlockCreated(
+		now,
+		h.playerID,
+		reqbody.TargetId,
+		oapi.CardTypeLgtm,
+		delay,
+		attack,
+	)
 	if err != nil {
 		return nil, err
 	}
@@ -350,7 +377,14 @@ func (h *wsHandler) handleStarstruck(reqbody oapi.WsRequestBodyCardEvent, now ti
 		targetRail.ID,
 	))
 
-	res, err := oapi.NewWsResponseBlockCreated(now, h.playerID, reqbody.TargetId, delay, attack)
+	res, err := oapi.NewWsResponseBlockCreated(
+		now,
+		h.playerID,
+		reqbody.TargetId,
+		oapi.CardTypeStarstruck,
+		delay,
+		attack,
+	)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/usecases/services/ws/wshandler/life.go
+++ b/internal/usecases/services/ws/wshandler/life.go
@@ -43,7 +43,12 @@ func (h *wsHandler) handleLifeEvent(body oapi.WsRequest_Body) error {
 	var res *oapi.WsResponse
 
 	if life := domain.CalculateLife(target.LifeEvents); life > 0 {
-		res, err = oapi.NewWsResponseLifeChanged(now, h.playerID, life)
+		res, err = oapi.NewWsResponseLifeChanged(
+			now,
+			h.playerID,
+			oapi.CardTypeNone,
+			life,
+		)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
- :recycle: life as schema, new -> newLife
- :recycle: add targetID to BlockEvent
- :fire: remove cardReset
- :sparkles: add CardType to WsRequestBodyBlockEvent
- :sparkles: add cardType to response
